### PR TITLE
Add responsive styles for login and dashboard

### DIFF
--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -17,10 +17,10 @@ export default function Dashboard({ token, onLogout }) {
   }, [token]);
 
   return (
-    <div>
+    <div className="dash-container">
       <h2>Dashboard</h2>
-      <button onClick={onLogout}>Logout</button>
-      <ul>
+      <button className="logout-btn" onClick={onLogout}>Logout</button>
+      <ul className="brand-list">
         {brands.map(b => (
           <li key={b.id}>{b.name}</li>
         ))}

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -24,11 +24,20 @@ export default function Login({ onLogin }) {
   };
 
   return (
-    <div>
+    <div className="auth-container">
       <h2>{isRegister ? 'Register' : 'Login'}</h2>
-      <form onSubmit={handleSubmit}>
-        <input placeholder="email" value={email} onChange={e => setEmail(e.target.value)} />
-        <input type="password" placeholder="password" value={password} onChange={e => setPassword(e.target.value)} />
+      <form onSubmit={handleSubmit} className="auth-form">
+        <input
+          placeholder="email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
         {isRegister && (
           <>
             <select value={type} onChange={e => setType(e.target.value)}>
@@ -45,7 +54,7 @@ export default function Login({ onLogin }) {
         )}
         <button type="submit">Submit</button>
       </form>
-      <button onClick={() => setIsRegister(!isRegister)}>
+      <button className="toggle-btn" onClick={() => setIsRegister(!isRegister)}>
         {isRegister ? 'Have an account? Login' : 'No account? Register'}
       </button>
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,79 @@
+/* Global styles and responsive breakpoints */
+:root {
+  --spacing: 1rem;
+  --font-size: 16px;
+}
+
+body {
+  margin: 0;
+  font-family: sans-serif;
+  font-size: var(--font-size);
+  padding: var(--spacing);
+}
+
+.auth-container,
+.dash-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing);
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing);
+}
+
+.auth-form input,
+.auth-form select,
+.auth-form button,
+.logout-btn,
+.toggle-btn {
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+.brand-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing);
+}
+
+.brand-list li {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+/* Larger screens: switch lists to grid */
+@media (min-width: 600px) {
+  .auth-container,
+  .dash-container {
+    max-width: 600px;
+  }
+
+  .brand-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  }
+}
+
+/* Small screens: adjust font size and spacing */
+@media (max-width: 480px) {
+  body {
+    font-size: 14px;
+    padding: 0.5rem;
+  }
+
+  .auth-form input,
+  .auth-form select,
+  .auth-form button,
+  .logout-btn,
+  .toggle-btn {
+    font-size: 0.9rem;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- add global stylesheet with breakpoints and flex/grid utilities
- wire stylesheet into app and update login & dashboard components to use classes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ada0e2b2d08329a998fc43dfca806c